### PR TITLE
[FIX]修复底部弹幕缺失

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ sed -i 's#</body>#<script src="https://jellyfin-danmaku.pages.dev/ede.user.js" d
   - 设置弹幕大小[0,30]
   - 设置弹幕区域占屏幕的高度比例[0,1]
   - 设置弹幕用户名过滤,支持选项[B.G.D.O]:
-    - 分别对应:哔哩哔哩,巴哈姆特,纯数字ID,其他ID
+    - 分别对应:哔哩哔哩,巴哈姆特,弹弹Play,其他
 
  **除0级外均带有每3秒6条的垂直方向弹幕密度限制,高于该限制密度的顶部/底部弹幕将会被转为普通弹幕*
 
 ## 弹幕
 
-弹幕来源为 [弹弹 play](https://www.dandanplay.com/) ,已开启弹幕聚合(Acfun/Bili/Tucao/Baha/5dm/Iqiyi站等不知名网站弹幕融合)
+弹幕来源为 [弹弹 play](https://www.dandanplay.com/) ,已开启弹幕聚合(Acfun/Bili/Tucao/Baha/5DM/iQIYI等不知名网站弹幕融合)
 
 ## 数据
 

--- a/ede.js
+++ b/ede.js
@@ -3,7 +3,7 @@
 // @description  Jellyfin弹幕插件
 // @namespace    https://github.com/RyoLee
 // @author       RyoLee
-// @version      1.20
+// @version      1.21
 // @copyright    2022, RyoLee (https://github.com/RyoLee)
 // @license      MIT; https://raw.githubusercontent.com/Izumiko/jellyfin-danmaku/jellyfin/LICENSE
 // @icon         https://github.githubassets.com/pinned-octocat.svg
@@ -625,7 +625,8 @@
             wrapper.id = 'danmakuWrapper';
             wrapper.style.position = 'absolute';
             wrapper.style.width = '100%';
-            wrapper.style.height = window.ede.heightRatio * 100 + '%';
+            wrapper.style.height = `${window.ede.heightRatio * 98}%`;
+            wrapper.style.opacity = window.ede.opacity;
             wrapper.style.top = '18px';
             wrapper.style.overflow = 'hidden';
             _container.prepend(wrapper);
@@ -635,11 +636,8 @@
                 media: _media,
                 comments: _comments,
                 engine: 'canvas',
+                speed: window.ede.speed,
             });
-
-            wrapper.lastChild.style.opacity = window.ede.opacity;
-            window.ede.danmaku.speed = window.ede.speed
-            wrapper.style.height = `${window.ede.heightRatio * 100}%`;
 
             window.ede.danmakuSwitch == 1 ? window.ede.danmaku.show() : window.ede.danmaku.hide();
             if (window.ede.obResize) {

--- a/ede.js
+++ b/ede.js
@@ -625,7 +625,7 @@
             wrapper.id = 'danmakuWrapper';
             wrapper.style.position = 'absolute';
             wrapper.style.width = '100%';
-            wrapper.style.height = `${window.ede.heightRatio * 98}%`;
+            wrapper.style.height = `calc(${window.ede.heightRatio * 100}% - 18px)`;
             wrapper.style.opacity = window.ede.opacity;
             wrapper.style.top = '18px';
             wrapper.style.overflow = 'hidden';


### PR DESCRIPTION
![屏幕截图 2024-01-23 202019](https://github.com/Izumiko/jellyfin-danmaku/assets/72293030/47889d98-7609-42de-81c7-685d5cd711bd)
如图，1.20版本当高度限制为1时底部弹幕只剩下字头