### PR TITLE
修复第三方弹幕获取和过滤

### DIFF
--- a/ede.js
+++ b/ede.js
@@ -977,19 +977,15 @@
         try {
             let response = await makeGetRequest(url_all);
             let data = isInTampermonkey ? JSON.parse(response) : await response.json();
-            const nonDandan = /^\[(?!BiliBili|Gamer).{3,}\]/; // 匹配其他弹幕
-            let hasRelated = false;
-            for (const c of data.comments) {
-                if (nonDandan.test(c.p.split(',').pop())) {
-                    hasRelated = true;
-                    break;
+            const matchBili = /^\[BiliBili\]/;
+            let hasBili = false;
+            if ((danmakuFilter & 1) !== 1) {
+                for (const c of data.comments) {
+                    if (matchBili.test(c.p.split(',').pop())) {
+                        hasBili = true;
+                        break;
+                    }
                 }
-            }
-            if (hasRelated) { // 实际包含第三方弹幕
-                showDebugInfo('弹幕下载成功: ' + data.comments.length);
-                return data.comments;
-            } else {
-                showDebugInfo('缺少第三方弹幕，尝试获取');
             }
             let comments = data.comments;
             response = await makeGetRequest(url_related);
@@ -1000,7 +996,10 @@
                 // 根据设置过滤弹幕源
                 let src = [];
                 for (const s of data.relateds) {
-                    if ((danmakuFilter & 1) !== 1 && s.url.includes('bilibili')) {
+                    if ((danmakuFilter & 1) !== 1 && !hasBili && s.url.includes('bilibili.com/bangumi')) {
+                        src.push(s.url);
+                    }
+                    if ((danmakuFilter & 1) !== 1 && s.url.includes('bilibili.com/video')) {
                         src.push(s.url);
                     }
                     if ((danmakuFilter & 2) !== 2 && s.url.includes('gamer')) {

--- a/ede.js
+++ b/ede.js
@@ -977,7 +977,7 @@
         try {
             let response = await makeGetRequest(url_all);
             let data = isInTampermonkey ? JSON.parse(response) : await response.json();
-            const nonDandan = /^.{3,}\]/; // 匹配非弹弹play弹幕
+            const nonDandan = /^\[(?!BiliBili|Gamer).{3,}\]/; // 匹配其他弹幕
             let hasRelated = false;
             for (const c of data.comments) {
                 if (nonDandan.test(c.p.split(',').pop())) {
@@ -1406,7 +1406,7 @@
             .filter((comment) => {
                 const user = comment.p.split(',')[3];
                 const modeId = parseInt(comment.p.split(',')[1], 10);
-                return !danmakuFilteRule.test(comment.m) && enabledMode.includes(modeId);
+                return !danmakuFilteRule.test(user) && enabledMode.includes(modeId);
             })
             .map((comment) => {
                 const [time, modeId, colorValue] = comment.p.split(',').map((v, i) => i === 0 ? parseFloat(v) : parseInt(v, 10));


### PR DESCRIPTION
dandanplay默认在bili弹幕多于一定阈值后不会补充gamer弹幕,或者只补充一小部分
弹幕充足的番剧使用之前的版本会获取不到gamer弹幕

单独对bili弹幕做了判断,以减少后续去重时的工作

dandanplay补充bili弹幕源的时候好像都有一次全部补充,不会像gamer源只补充一部分,所以这样应该不会有漏掉的弹幕