### PR TITLE
修复 jellyfin 10.10 非管理员账号无法使用弹幕的问题

### DIFF
--- a/ede.js
+++ b/ede.js
@@ -3,7 +3,7 @@
 // @description  Jellyfin弹幕插件
 // @namespace    https://github.com/RyoLee
 // @author       RyoLee
-// @version      1.49
+// @version      1.50
 // @copyright    2022, RyoLee (https://github.com/RyoLee)
 // @license      MIT; https://raw.githubusercontent.com/Izumiko/jellyfin-danmaku/jellyfin/LICENSE
 // @icon         https://github.githubassets.com/pinned-octocat.svg
@@ -59,7 +59,6 @@
     const originalOpen = XMLHttpRequest.prototype.open;
     XMLHttpRequest.prototype.open = function (_, url) {
         this.addEventListener('load', function () {
-            console.log('XMLHttpRequest to:', url);
             if (url.endsWith('PlaybackInfo')) {
                 const res = JSON.parse(this.responseText);
                 itemId = res.MediaSources[0].Id;
@@ -1515,8 +1514,13 @@
             }
 
             (async () => {
-                while (!(await ApiClient.getSessions())) {
+                let retry = 0;
+                while (!itemId) {
                     await new Promise((resolve) => setTimeout(resolve, 200));
+                    retry++;
+                    if (retry > 10) {
+                        throw new Error('获取itemId失败');
+                    }
                 }
 
                 setInterval(() => {


### PR DESCRIPTION
jellyfin 10.10 似乎更新了 `Sessions` 接口的权限，导致非管理员用户调用此接口导致 500 而无法获取到视频信息。

目前给出的解决方法就是获取 `itemId` 再使用 `ApiClient` 上的 `getItem` 方法获取视频信息，尚未测试在低于 10.10 版本的 jellyfin 上是否正常运行。