### PR TITLE
docs:  更新 README.md 文档，补充 Caddy (replace_response 插件) replace 指令示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,12 @@ example.com {
 下载Caddy二进制文件时，增加模块[`caddyserver/replace-response`](https://github.com/caddyserver/replace-response)，之后，在`Caddyfile`中按如下内容修改
 
 ```Caddyfile
-# 全局设置
-{
-    order filter after encode
-}
-
 # 网站设置
 example.com {
-    replace {
+    replace /web/* {
+        match {
+            header Content-Type text/html*
+        }
         "</body>" "<script src=\"https://cdn.jsdelivr.net/gh/Izumiko/jellyfin-danmaku@gh-pages/ede.user.js\" defer></script></body>"
     }
     reverse_proxy localhost:8096 {


### PR DESCRIPTION
1. 删掉文档 [2.3 Caddy (replace_response 插件)](https://github.com/Izumiko/jellyfin-danmaku/blob/70a8827487d1751217e17ee96f0cbc356533d981/README.md?plain=1#L130) 全局配置示例，它是 [sjtug/caddy2-filter](https://github.com/sjtug/caddy2-filter) 的全局配置
2. 添加请求匹配器只对 web 路径进行处理，添加响应匹配器只对 html 文件进行替换。

文档 [2.3 Caddy (replace_response 插件)](https://github.com/Izumiko/jellyfin-danmaku/blob/70a8827487d1751217e17ee96f0cbc356533d981/README.md?plain=1#L130) 会对所有返回的响应体做替换尝试，无法正常加载 jellyfin 页面，需要添加匹配器